### PR TITLE
Benchmarking tests

### DIFF
--- a/treap_test.go
+++ b/treap_test.go
@@ -2,8 +2,14 @@ package treap
 
 import (
         "fmt"
+	"rand"
         "testing"
 )
+
+func init() {
+	// so that every run is the same seq of rand numbers
+	rand.Seed(0)
+}
 
 func StringLess(p, q interface{}) bool {
         return p.(string) < q.(string)
@@ -272,4 +278,42 @@ func TestRightRotate(t *testing.T) {
         if b.right != e {
                 t.Errorf("expected b.right to be e")
         }
+}
+
+func treeOfInts(ints []int) (tree *Tree) {
+	tree = NewTree(IntLess)
+	for _, i := range ints {
+		tree.Insert(i, i)
+	}
+	return
+}
+
+func BenchmarkInsert(b *testing.B) {
+	b.StopTimer()
+	ints := rand.Perm(b.N)
+	b.StartTimer()
+	_ = treeOfInts(ints)
+}
+
+func BenchmarkDelete(b *testing.B) {
+	b.StopTimer()
+	ints := rand.Perm(b.N)
+	tree := treeOfInts(ints)
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tree.Delete(i)
+	}
+}
+
+func BenchmarkLookup(b *testing.B) {
+	b.StopTimer()
+	ints := rand.Perm(b.N)
+	tree := treeOfInts(ints)
+	b.StartTimer()
+	for j := 0; j < 10; j++ {
+		for i := 0; i < len(ints)/10; i++ {
+			_ = tree.Exists(ints[i])
+		}
+	}
 }


### PR DESCRIPTION
Hello,

I wanted to experiment with Go's profiler, so I added some benchmarking tests to my fork of treap. I didn't find any clear performance bottlenecks, but the experience was interesting.

According to the profiler, go's runtime spends a lot of time typechecking, because of the use of interface{} types to hold generic data types. It is clear that a specialized version of treap that holds ust ints or just strings or whatever would be quite a bit faster. But that's a different project entirely, so not gonna go there...

Anyway, the benchmarks are still interesting, in case you want to check that future changes you make don't make things slower.

To use them, type "gomake bench".

  -jeff
